### PR TITLE
test : 영감 및 태그 조회시 I/O를 줄이기 위한 캐싱 전략

### DIFF
--- a/module-api/src/main/java/inspiration/tag/TagService.java
+++ b/module-api/src/main/java/inspiration/tag/TagService.java
@@ -7,11 +7,15 @@ import inspiration.member.MemberService;
 import inspiration.tag.request.TagAddRequest;
 import inspiration.tag.response.TagResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@CacheConfig(cacheNames = "findTags")
 @RequiredArgsConstructor
 @Service
 @Transactional
@@ -20,6 +24,7 @@ public class TagService {
     private final TagRepository tagRepository;
     private final MemberService memberService;
 
+    @Cacheable(value = "findTags")
     @Transactional(readOnly = true)
     public Page<TagResponse> findTags(Pageable pageable, Long memberId) {
 
@@ -29,6 +34,7 @@ public class TagService {
         return tagPage.map(TagResponse::from);
     }
 
+    @CacheEvict(allEntries = true)
     public Long addTag(TagAddRequest request, Long memberId) {
 
         Member member = memberService.findById(memberId);
@@ -38,6 +44,7 @@ public class TagService {
         return tagRepository.save(tag).getId();
     }
 
+    @CacheEvict(allEntries = true)
     public void removeTag(Long id, Long memberId) {
         Tag tag = tagRepository.findById(id)
                                 .orElseThrow(ResourceNotFoundException::new);

--- a/module-web/src/main/java/inspiration/Application.java
+++ b/module-web/src/main/java/inspiration/Application.java
@@ -2,11 +2,10 @@ package inspiration;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.data.web.SpringDataWebAutoConfiguration;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.context.annotation.ComponentScan;
+import org.springframework.cache.annotation.EnableCaching;
 
-
+@EnableCaching
 @SpringBootApplication
 @ConfigurationPropertiesScan("inspiration.property")
 public class Application {


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- #30 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 영감 및 태그 조회시 I/O를 줄이기 위한 캐싱 전략
- 영감 및 태그 삭제, 삽입, 수정 시 캐싱 삭제

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
- 레디스 캐시 서버를 두고 캐싱 작업을 진행하고 싶었으나, 디프만에서 지원해주는 ec2의 메모리 한계로 인해 그냥 스프링에서 내부의 캐시 저장소 사용

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [ ] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
