### PR TITLE
feat: 구글 시트로 tag group 조회

### DIFF
--- a/module-batch/build.gradle
+++ b/module-batch/build.gradle
@@ -3,6 +3,7 @@ dependencies {
     implementation project(':module-api')
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework:spring-web'
     implementation "org.apache.commons:commons-csv:$apacheCommonsCsvVersion"
     implementation "com.slack.api:slack-api-client:$slackSdkVersion"
     implementation "com.squareup.okhttp3:okhttp:$okhttpVersion"

--- a/module-batch/src/main/java/inspiration/application/tag/TagGroup.java
+++ b/module-batch/src/main/java/inspiration/application/tag/TagGroup.java
@@ -1,0 +1,29 @@
+package inspiration.application.tag;
+
+import org.springframework.util.Assert;
+
+import java.util.List;
+
+@SuppressWarnings("ClassCanBeRecord")
+public class TagGroup {
+    private final String name;
+    private final List<String> candidates;
+
+    private TagGroup(String name, List<String> candidates) {
+        this.name = name;
+        this.candidates = candidates;
+    }
+
+    public static TagGroup from(List<String> candidates) {
+        Assert.notEmpty(candidates, "'candidates' must not be null or empty");
+        return new TagGroup(candidates.get(0), candidates);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean contains(String name) {
+        return candidates.stream().anyMatch(it -> it.equalsIgnoreCase(name));
+    }
+}

--- a/module-batch/src/main/java/inspiration/application/tag/TagGroupService.java
+++ b/module-batch/src/main/java/inspiration/application/tag/TagGroupService.java
@@ -1,0 +1,7 @@
+package inspiration.application.tag;
+
+import java.util.List;
+
+public interface TagGroupService {
+    List<TagGroup> getTagGroups();
+}

--- a/module-batch/src/main/java/inspiration/infrastructure/google/GoogleApiConfig.java
+++ b/module-batch/src/main/java/inspiration/infrastructure/google/GoogleApiConfig.java
@@ -1,0 +1,44 @@
+package inspiration.infrastructure.google;
+
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.support.HttpRequestWrapper;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.Duration;
+
+@Configuration
+public class GoogleApiConfig {
+    @Value("${ygtang.google.api-key}")
+    private String googleApiKey;
+
+    @Bean
+    public RestTemplate googleApiRestTemplate() {
+        return new RestTemplateBuilder()
+                       .additionalInterceptors(
+                               (request, body, execution) -> {
+                                   URI uri = UriComponentsBuilder.fromHttpRequest(request)
+                                                                 .queryParam("key", googleApiKey)
+                                                                 .build().toUri();
+
+                                   HttpRequest modifiedRequest = new HttpRequestWrapper(request) {
+                                       @NotNull
+                                       @Override
+                                       public URI getURI() {
+                                           return uri;
+                                       }
+                                   };
+                                   return execution.execute(modifiedRequest, body);
+                               }
+                       )
+                       .setConnectTimeout(Duration.ofSeconds(1L))
+                       .setReadTimeout(Duration.ofSeconds(3L))
+                       .build();
+    }
+}

--- a/module-batch/src/main/java/inspiration/infrastructure/google/GoogleSheetTagGroupService.java
+++ b/module-batch/src/main/java/inspiration/infrastructure/google/GoogleSheetTagGroupService.java
@@ -1,0 +1,79 @@
+package inspiration.infrastructure.google;
+
+import inspiration.application.tag.TagGroup;
+import inspiration.application.tag.TagGroupService;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@SuppressWarnings("ClassCanBeRecord")
+public class GoogleSheetTagGroupService implements TagGroupService {
+    private final RestTemplate googleApiRestTemplate;
+
+    @Value("${ygtang.google.sheet-id.tag-group}")
+    private String tagGroupSheetId;
+
+    @Override
+    public List<TagGroup> getTagGroups() {
+        ResponseEntity<GoogleSheetResponse> responseEntity = googleApiRestTemplate.getForEntity(
+                UriComponentsBuilder.newInstance()
+                                    .scheme("https")
+                                    .host("sheets.googleapis.com")
+                                    .path("/v4/spreadsheets/{spreadsheetId}")
+                                    .queryParam("ranges", "A1:J1000")
+                                    .queryParam("includeGridData", "true")
+                                    .build(tagGroupSheetId),
+                GoogleSheetResponse.class
+        );
+        if (responseEntity.getBody() == null) {
+            throw new IllegalStateException("Failed to get tag groups from Google Sheet Api");
+        }
+        return responseEntity.getBody().getSheets().get(0).getData().get(0).getRowData()
+                             .stream()
+                             .map(it -> TagGroup.from(
+                                     it.getValues()
+                                       .stream()
+                                       .filter(Objects::nonNull)
+                                       .map(ValuesResponse::getFormattedValue)
+                                       .collect(Collectors.toList())
+                                     )
+                             )
+                             .collect(Collectors.toList());
+    }
+
+    @Data
+    static class GoogleSheetResponse {
+        List<SheetsResponse> sheets;
+    }
+
+    @Data
+    static class SheetsResponse {
+        List<DataResponse> data;
+    }
+
+    @Data
+    static class DataResponse {
+        List<RowDataResponse> rowData;
+    }
+
+    @Data
+    static class RowDataResponse {
+        List<ValuesResponse> values;
+    }
+
+    @Data
+    static class ValuesResponse {
+        String formattedValue;
+    }
+}
+

--- a/module-batch/src/main/java/inspiration/infrastructure/google/GoogleSheetTagGroupService.java
+++ b/module-batch/src/main/java/inspiration/infrastructure/google/GoogleSheetTagGroupService.java
@@ -7,11 +7,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
@@ -43,8 +43,8 @@ public class GoogleSheetTagGroupService implements TagGroupService {
                              .map(it -> TagGroup.from(
                                      it.getValues()
                                        .stream()
-                                       .filter(Objects::nonNull)
                                        .map(ValuesResponse::getFormattedValue)
+                                       .filter(StringUtils::hasText)
                                        .collect(Collectors.toList())
                                      )
                              )

--- a/module-batch/src/main/resources/batch.yml
+++ b/module-batch/src/main/resources/batch.yml
@@ -6,4 +6,6 @@ spring:
 ygtang:
   slack:
     token:
-      bot: ENC(/vYHx8EfqXQ5Q+wUpBxmEkde8Nz0i32a1I1uFPzi7X5bOsfQ1/BU7/enM9DMzHt2VO7FwgOELpKfAkjc98kzHG4stHPZKF3mJ5Xqf0p9SeAEyMvv+Y6JPZojjQ755zAT)
+      bot: DEC(xoxb-3651644455301-3943686520132-NVE0FRzXGtT6lsCESoktbFx1)
+  google:
+    api-key: ENC(eSD4S2QU5YycRNsFnwcVBXfcjyhZZZGt752BAZEORv5WgbT60yy1VGDiKrpq6NYBbN0wVKNXSc78/OVrc2sr7X4anCsUjRh81mykpr9PWTM=)

--- a/module-batch/src/main/resources/batch.yml
+++ b/module-batch/src/main/resources/batch.yml
@@ -6,6 +6,8 @@ spring:
 ygtang:
   slack:
     token:
-      bot: DEC(xoxb-3651644455301-3943686520132-NVE0FRzXGtT6lsCESoktbFx1)
+      bot: ENC(tiq6tuKYXrEiqutBkfkXJxKFiHBO7JlCgPDH8zAiU/C72XsYPXZuDZ+ZWAkx871dBAKF+befdkDbQZ1SF2eHVPa2pemI38jqmszaycYcic0hnzY9EVcDNMOmPTLJauPT)
   google:
     api-key: ENC(eSD4S2QU5YycRNsFnwcVBXfcjyhZZZGt752BAZEORv5WgbT60yy1VGDiKrpq6NYBbN0wVKNXSc78/OVrc2sr7X4anCsUjRh81mykpr9PWTM=)
+    sheet-id:
+      tag-group: ENC(W5y38wS4Qp1HatcqmlZqTRVcylum+99xzcLyKbf+UC/H4sdhpv8V9du2KfevbClTQBChW2nxo/6BerOK4Kp4rZv4Jfr9W+woHlIWyhPze4M=)


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- resolve #162 
- resolve #163 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- 태그 순위 집계할 때, 이름은 다르지만 같은의미로 판단하는 태그 그룹 목록 개념을 추가합니다. 
- 태그 그룹 정보는 구글 시트를 통해 조회합니다. 

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
-

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [ ] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [ ] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
