### PR TITLE
refactor: ForkJoinPool 기본 스레드풀 대신 직접 생성한 스레드 풀 사용

### DIFF
--- a/module-api/src/main/java/inspiration/domain/inspiration/InspirationService.java
+++ b/module-api/src/main/java/inspiration/domain/inspiration/InspirationService.java
@@ -25,15 +25,16 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -50,6 +51,7 @@ public class InspirationService {
     private final InspirationTagRepository inspirationTagRepository;
     private final TagRepository tagRepository;
     private final OpenGraphService openGraphService;
+    private final ThreadPoolTaskExecutor threadPoolTaskExecutor;
 
     @Transactional(readOnly = true)
     public RestPage<InspirationResponse> findInspirations(Pageable pageable, Long memberId) {
@@ -268,16 +270,19 @@ public class InspirationService {
     }
 
     private RestPage<InspirationResponse> toRestPage(Page<Inspiration> inspirationPage) {
-        final Map<Long, OpenGraphResponse> inspirationOpenGraphMap;
-        inspirationOpenGraphMap = inspirationPage.getContent()
-                       .parallelStream()
-                       .collect(
-                               Collectors.toMap(
-                                       Inspiration::getId,
-                                       it -> getOpenGraphResponse(it.getType(), it.getContent())
-                               )
-                       );
-
+        final Map<Long, OpenGraphResponse> inspirationOpenGraphMap = new ConcurrentHashMap<>();
+        // executor 에 작업 할당
+        final List<CompletableFuture<Void>> completableFutures = inspirationPage.map(
+                inspiration -> CompletableFuture.runAsync(
+                        () -> inspirationOpenGraphMap.put(
+                                inspiration.getId(),
+                                getOpenGraphResponse(inspiration.getType(), inspiration.getContent())
+                        ),
+                        threadPoolTaskExecutor
+                )
+        ).toList();
+        // 비동기 작업 끝날때까지 대기
+        completableFutures.forEach(CompletableFuture::join);
         return new RestPage<>(
                 inspirationPage.stream()
                                .peek(it -> it.setFilePath(getFilePath(it.getType(), it.getContent())))

--- a/module-domain/src/main/java/inspiration/infrastructure/spring/ExecutorConfig.java
+++ b/module-domain/src/main/java/inspiration/infrastructure/spring/ExecutorConfig.java
@@ -1,0 +1,23 @@
+package inspiration.infrastructure.spring;
+
+import org.springframework.boot.task.TaskExecutorBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.time.Duration;
+
+@Configuration
+public class ExecutorConfig {
+    @Bean
+    public ThreadPoolTaskExecutor threadPoolTaskExecutor() {
+        return new TaskExecutorBuilder()
+                .corePoolSize(12)
+                .maxPoolSize(12)
+                .queueCapacity(200)
+                .awaitTermination(true)
+                .awaitTerminationPeriod(Duration.ofSeconds(10))
+                .threadNamePrefix("task-executor-")
+                .build();
+    }
+}


### PR DESCRIPTION
<!--
✅ Resolve: #이슈번호 형태로 입력해 주세요.
ex) Resolve: #123
-->
## 📌Linked Issues
- resolve #192 

<!--
✅ 변경 사항을 자세히 알려주세요. (why -> what -> how)
-->
## ✏Change Details
- ForkJoinPool 대신 직접 생성한 thread pool 사용
  - 낮은 사양 ec2 는 코어 수가 적어서, 충분한 thread 개수 확보 못할수도 있음
- 보통 12개짜리 페이지 요청하므로 thread 12개로 설정

<!--
✅ 추가로 전달할 내용이 있다면 적어주세요.
-->
## 💬Comment
-

<!--
✅ 참고한 사이트가 있다면 공유해주세요.
-->
## 📑References
- 

## ✅Check List
- [x] 추가한 기능에 대한 테스트는 모두 완료하셨나요?
- [x] 코드 정렬(Ctrl + Alt + L), 불필요한 코드나 오타는 없는지 확인하셨나요?
